### PR TITLE
Fix underscores en texto cursiva

### DIFF
--- a/10-Web-features/2-formularios-en-php.md
+++ b/10-Web-features/2-formularios-en-php.md
@@ -168,7 +168,7 @@ if(isset($_POST["submit"]) && $_SERVER["REQUEST_METHOD"] == "POST"){
 }
 ```
 
-Para **aceptar los datos** se ha puesto _isset($_POST["submit"])_, que crea la _**key**_ _submit_ cuando se hace click en el botón, y _$_SERVER["REQUEST_METHOD"] == "post"_, que especifica que el **método _request_** ha de ser POST. Se puede usar una de las dos formas o las dos a la vez.
+Para **aceptar los datos** se ha puesto _isset($\_POST["submit"])_, que crea la _**key**_ _submit_ cuando se hace click en el botón, y _$\_SERVER["REQUEST_METHOD"] == "post"_, que especifica que el **método _request_** ha de ser POST. Se puede usar una de las dos formas o las dos a la vez.
 
 Para **mostrar los datos**:
 


### PR DESCRIPTION
Mientras leía el texto en el párrafo:

Para aceptar los datos se ha puesto isset($_POST["submit"]), que crea la key submit cuando se hace click en el botón, y $_SERVER["REQUEST_METHOD"] == "post", que especifica que el método request ha de ser POST. Se puede usar una de las dos formas o las dos a la vez.

He visto que la cursiva se aplicaba incorrectamente y que aparecían guiones bajos donde no tenía sentido (por ejemplo, previo al isset). Al ver el código del markdown, he visto que no se habían usado los backslash como escape para los guiones bajos. Creo que ahora se debería ver bien.